### PR TITLE
Fix release notifications

### DIFF
--- a/.slackbot.yml
+++ b/.slackbot.yml
@@ -1,15 +1,9 @@
+# This is a sample release schedule.
 releaseSchedule:
-  tfili: 2/4/2019
-  ggetz: 3/4/2019
-  hpinkos: 4/1/2019
-  lilleyse: 5/2/2019
-  gary: 6/3/2019
-  mamato: 7/1/2019
-  dbagnell: 8/1/2019
-
-greetings:
-  - Happy Friday everyone!
-  - Can you believe Friday is already here?
-  - I hope you all had awesome week!
-  - I skipped breakfast, so I hope Gary baked something good today...
-  - Good morning everyone!
+  - tfili, 2/4/2019
+  - ggetz, 3/4/2019
+  - hpinkos, 4/1/2019
+  - lilleyse, 5/2/2019
+  - gary, 6/3/2019
+  - mamato, 7/1/2019
+  - dbagnell, 8/1/2019

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6"
+  - "10"
 sudo: false
 dist: trusty
 script:

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -64,15 +64,9 @@ SlackBot.initializeScheduledJobs = function() {
   var releaseReminder = schedule.scheduleJob('0 8 * * *', function(){
     that._sendReleaseReminders().catch(console.error);
   });
-
-  // Set up weekly Slack message every Friday morning.
-  var weeklyStats = schedule.scheduleJob('0 8 * * FRI', function(){
-    that._sendWeeklyStats().catch(console.error);
-  });
-
+  
   return {
-    releaseReminder: releaseReminder,
-    weeklyStats: weeklyStats
+    releaseReminder: releaseReminder
   };
 };
 
@@ -161,62 +155,6 @@ SlackBot._getAllPullRequestsMergedLastWeek = function(repositoryNames) {
     });
 };
 
-SlackBot._sendWeeklyStats = function() {
-    var repositoryNames = Object.keys(this._repositories);
-    var longestMergeTime = 0;
-    var longestPullRequest;
-    var mergeTimes = [];
-    var that = this;
-
-    return Promise.each(this._getAllPullRequestsMergedLastWeek(repositoryNames),
-      function(pullRequest) {
-          var endTime = moment(pullRequest.closed_at);
-          var startTime = moment(pullRequest.created_at);
-          var daysDifference = endTime.diff(startTime, 'days');
-          mergeTimes.push(daysDifference);
-
-          if (!defined(longestPullRequest) || daysDifference > longestMergeTime) {
-            longestPullRequest = pullRequest;
-            longestMergeTime = daysDifference;
-          }
-      })
-      .then(function() {
-        return that._getConfig();
-      })
-      .then(function(slackBotSettings) {
-        var greetings = slackBotSettings.greetings;
-        if (!defined(greetings)) {
-          greetings = ['Happy Friday everyone!'];
-        }
-
-        var averageMergeTime = getAverage(mergeTimes).toFixed(1);
-        longestMergeTime = longestMergeTime.toFixed(1);
-
-        // Compute the standard deviation. If the longest merge time is more than 3 times that, report is as unusual.
-        var deviation = getStandardDeviation(mergeTimes);
-        var longMergeTitle;
-
-        if (Math.abs(longestMergeTime - averageMergeTime) >= deviation * 2) {
-          longMergeTitle = longestPullRequest.title;
-        }
-
-        var greeting = greetings[Math.floor(Math.random() * greetings.length)];
-        var templateName = 'weeklyStats';
-        var template = fs.readFileSync(path.join(__dirname, 'templates', templateName + '.hbs')).toString();
-
-        var messageText = handlebars.compile(template)({
-          greeting : greeting,
-          averageMergeTime : averageMergeTime,
-          numberOfPullRequests : mergeTimes.length,
-          longMergeTitle : longMergeTitle,
-          longMergeTime : longestMergeTime,
-          longMergeURL : longestPullRequest.html_url
-        });
-
-        return that.postMessage(that._channelIDs['general'], messageText);
-      });
-};
-
 SlackBot._sendReleaseReminders = function() {
   // Update config before we post any reminders,
   // that way, we can update the config and the bot will always have the latest copy.
@@ -226,30 +164,36 @@ SlackBot._sendReleaseReminders = function() {
       var releaseSchedule = slackBotSettings.releaseSchedule;
       for (var user in releaseSchedule) {
         if (releaseSchedule.hasOwnProperty(user)) {
-          var today = moment().startOf('day');
-          var days = today.diff(releaseSchedule[user], 'days');
-          var templateName;
+          // A user may have multiple release dates (if they are doing the release in January and in April for example).
+          // We check all of them to send reminders.
+          var userDates = releaseSchedule[user];
+          for (var i = 0; i < userDates.length; i++) {
+            var date = userDates[i];
+            var today = moment().startOf('day');
+            var days = today.diff(date, 'days');
+            var templateName;
 
-          if (days === -14) {
-            templateName = 'releaseReminderEarly';
-          } else if (days === -7) {
-            templateName = 'releaseReminder';
-          } else if (days === 0) {
-            templateName = 'releaseReminderLate';
-          }
-
-          if (defined(templateName)) {
-            var userObject = that._userData[that._userIDs[user]];
-            var name = userObject.display_name;
-            if (!defined(name) || name.length === 0) {
-              name = userObject.real_name;
+            if (days === -14) {
+              templateName = 'releaseReminderEarly';
+            } else if (days === -7) {
+              templateName = 'releaseReminder';
+            } else if (days === 0) {
+              templateName = 'releaseReminderLate';
             }
-            var template = fs.readFileSync(path.join(__dirname, 'templates', templateName + '.hbs')).toString();
-            var messageText = handlebars.compile(template)({
-              name : name
-            });
 
-            return that.postMessage(that._userIDs[user], messageText);
+            if (defined(templateName)) {
+              var userObject = that._userData[that._userIDs[user]];
+              var name = userObject.display_name;
+              if (!defined(name) || name.length === 0) {
+                name = userObject.real_name;
+              }
+              var template = fs.readFileSync(path.join(__dirname, 'templates', templateName + '.hbs')).toString();
+              var messageText = handlebars.compile(template)({
+                name : name
+              });
+
+              return that.postMessage(that._userIDs[user], messageText);
+            }
           }
         }
       }
@@ -263,7 +207,6 @@ SlackBot._getConfig = function() {
   if (this._isDisabled) {
     return Promise.resolve('Warning: SlackBot is disabled.');
   }
-
   if (!defined(this._repoName)) {
     // If we find a config url but no token for that repo, print a warning.
     var matchResults = configUrl.match(repoNameRegex);
@@ -295,16 +238,20 @@ SlackBot._getConfig = function() {
         var yamlSchedule = configData['releaseSchedule'];
         var releaseSchedule = {};
 
-        for (var user in yamlSchedule) {
-          if (yamlSchedule.hasOwnProperty(user)) {
-            var date = moment(yamlSchedule[user], 'MM/DD/YYYY').startOf('day');
-            releaseSchedule[user] = date;
+        for (var i = 0; i < yamlSchedule.length; i++) {
+          var row = yamlSchedule[i];
+          var user = row.split(',')[0].trim();
+          var dateString = row.split(',')[1].trim();
+
+          var date = moment(dateString, 'MM/DD/YYYY').startOf('day');
+          if (!defined(releaseSchedule[user])) {
+            releaseSchedule[user] = [];
           }
+          releaseSchedule[user].push(date);
         }
 
         var slackBotSettings = {
-          releaseSchedule: releaseSchedule,
-          greetings: configData['greetings']
+          releaseSchedule: releaseSchedule
         };
 
         return slackBotSettings;

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -64,7 +64,7 @@ SlackBot.initializeScheduledJobs = function() {
   var releaseReminder = schedule.scheduleJob('0 8 * * *', function(){
     that._sendReleaseReminders().catch(console.error);
   });
-  
+
   return {
     releaseReminder: releaseReminder
   };
@@ -302,27 +302,5 @@ SlackBot._authenticateGitHub = function() {
     auth: 'token ' + this._repositories[repositoryNames[0]].gitHubToken
   });
 };
-
-function getStandardDeviation(values){
-  var average = getAverage(values);
-
-  var squaredDifferences = values.map(function(value){
-    return Math.pow(value - average, 2);
-  });
-
-  var averageSquaredDifference = getAverage(squaredDifferences);
-
-  var standardDeviation = Math.sqrt(averageSquaredDifference);
-  return standardDeviation;
-}
-
-function getAverage(data){
-  var sum = data.reduce(function(sum, value){
-    return sum + value;
-  }, 0);
-
-  var average = sum / data.length;
-  return average;
-}
 
 module.exports = SlackBot;

--- a/lib/templates/releaseReminder.hbs
+++ b/lib/templates/releaseReminder.hbs
@@ -2,6 +2,6 @@ Hey {{name}}! There's about a week to the CesiumJS release, which I believe you'
 
 Now would be a good time to triage the priority next release issues:
 
-https://github.com/AnalyticalGraphicsInc/cesium/issues?q=is%3Aopen+is%3Aissue+label%3A%22priority+-+next+release%22
+https://github.com/CesiumGS/cesium/issues?q=is%3Aopen+is%3Aissue+label%3A%22priority+-+next+release%22
 
 As well as make sure all tests are running in master, and no big last minute changes are being merged. 

--- a/lib/templates/releaseReminderEarly.hbs
+++ b/lib/templates/releaseReminderEarly.hbs
@@ -2,4 +2,4 @@ Hey {{name}}! This is just an early reminder that you are in charge of the Cesiu
 
 Make sure you keep your eye on issues with the `priority next release` label:
 
-https://github.com/AnalyticalGraphicsInc/cesium/issues?q=is%3Aopen+is%3Aissue+label%3A%22priority+-+next+release%22
+https://github.com/CesiumGS/cesium/issues?q=is%3Aopen+is%3Aissue+label%3A%22priority+-+next+release%22

--- a/lib/templates/releaseReminderLate.hbs
+++ b/lib/templates/releaseReminderLate.hbs
@@ -1,5 +1,5 @@
 Today's the big day {{name}}! You're in charge of CesiumJS's release. The release guide should have everything you need:
 
-https://github.com/AnalyticalGraphicsInc/cesium/wiki/Release-Guide
+https://github.com/CesiumGS/cesium/wiki/Release-Guide
 
 Best of luck!

--- a/lib/templates/weeklyStats.hbs
+++ b/lib/templates/weeklyStats.hbs
@@ -1,1 +1,0 @@
-{{greeting}} We merged *{{ numberOfPullRequests }}* PR's this week, with an average merge time of *{{ averageMergeTime }} days*. {{#if longMergeTitle}} The PR <{{ longMergeURL }}|{{ longMergeTitle }}> took an unusually long amount of time to get merged ({{ longMergeTime }} days).{{/if}}

--- a/specs/data/slackbot.yml
+++ b/specs/data/slackbot.yml
@@ -1,9 +1,3 @@
 releaseSchedule:
-  oshehata: 2/4/2019
-
-greetings:
-  - Happy Friday everyone!
-  - Can you believe Friday is already here?
-  - I hope you all had awesome week!
-  - I skipped breakfast, so I hope Gary baked something good today...
-  - Good morning everyone!
+  - oshehata, 2/4/2019
+  - oshehata, 8/1/2019


### PR DESCRIPTION
Fixes https://github.com/CesiumGS/cesium-concierge/issues/142 to make the slack bot send individuals on the team reminders when the release is happening.

* Changed structured of the `.slackbot.yml` to be an array instead of a dict, so that people can be listed more than once
* Removed the weekly stats message which we're not really using anymore
* Updated unit tests
* Updated node to fix Travis, but can't use node 12 because of this issue https://stackoverflow.com/questions/55921442/how-to-fix-referenceerror-primordials-is-not-defined-in-node ?

I've tested this locally with a mock YAML and confirmed the Slack bot will message me. Here is what the 3 messages look like (I've updated the links to be AGI -> CesiumGS):

![image](https://user-images.githubusercontent.com/1711126/94501444-d3e83280-01cf-11eb-8995-158ff8d056a8.png)


To do

* [x] Update release YAML in CesiumJS repo https://github.com/CesiumGS/cesium/pull/9179
* [ ] Deploy 