### PR TITLE
Make concierge post release reminders to #dev Slack channel

### DIFF
--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -188,7 +188,7 @@ SlackBot._sendReleaseReminders = function() {
               var userId = userObject.id;
               var template = fs.readFileSync(path.join(__dirname, 'templates', templateName + '.hbs')).toString();
               var messageText = handlebars.compile(template)({
-                userId : `<@${userId}>`
+                userId : '<@' + userId + '>'
               });
 
               return that.postMessage(that._channelIDs[SLACK_ANNOUNCEMENT_CHANNEL], messageText);

--- a/lib/SlackBot.js
+++ b/lib/SlackBot.js
@@ -18,6 +18,7 @@ var dateLog = require('./dateLog');
 var SlackBot = {};
 
 var repoNameRegex = /repos\/([\w-]+\/[\w-]+)/;
+var SLACK_ANNOUNCEMENT_CHANNEL = 'dev';
 
 /** Fetches Slack metadata and authenticates with GitHub. Sets Slackbot.ready to true when done.
  *
@@ -90,6 +91,7 @@ SlackBot.postMessage = function(channelId, message) {
       return that._slackClient.chat.postMessage({
         channel: channelId,
         text: message,
+        link_names: true,
         as_user: true
       });
     });
@@ -183,16 +185,13 @@ SlackBot._sendReleaseReminders = function() {
 
             if (defined(templateName)) {
               var userObject = that._userData[that._userIDs[user]];
-              var name = userObject.display_name;
-              if (!defined(name) || name.length === 0) {
-                name = userObject.real_name;
-              }
+              var userId = userObject.id;
               var template = fs.readFileSync(path.join(__dirname, 'templates', templateName + '.hbs')).toString();
               var messageText = handlebars.compile(template)({
-                name : name
+                userId : `<@${userId}>`
               });
 
-              return that.postMessage(that._userIDs[user], messageText);
+              return that.postMessage(that._channelIDs[SLACK_ANNOUNCEMENT_CHANNEL], messageText);
             }
           }
         }

--- a/lib/templates/releaseReminder.hbs
+++ b/lib/templates/releaseReminder.hbs
@@ -1,4 +1,4 @@
-Hey {{name}}! There's about a week to the CesiumJS release, which I believe you're in charge of!
+Hey {{{userId}}}! There's about a week to the CesiumJS release, which I believe you're in charge of!
 
 Now would be a good time to triage the priority next release issues:
 

--- a/lib/templates/releaseReminderEarly.hbs
+++ b/lib/templates/releaseReminderEarly.hbs
@@ -1,4 +1,4 @@
-Hey {{name}}! This is just an early reminder that you are in charge of the CesiumJS release for this month.
+Hey {{{userId}}}! This is just an early reminder that you are in charge of the CesiumJS release for this month.
 
 Make sure you keep your eye on issues with the `priority next release` label:
 

--- a/lib/templates/releaseReminderLate.hbs
+++ b/lib/templates/releaseReminderLate.hbs
@@ -1,4 +1,4 @@
-Today's the big day {{name}}! You're in charge of CesiumJS's release. The release guide should have everything you need:
+Today's the big day {{{userId}}}! You're in charge of CesiumJS's release. The release guide should have everything you need:
 
 https://github.com/CesiumGS/cesium/wiki/Release-Guide
 

--- a/specs/lib/SlackBotSpec.js
+++ b/specs/lib/SlackBotSpec.js
@@ -42,7 +42,7 @@ describe('SlackBot', function () {
         var template = fs.readFileSync(path.join(__dirname, '../../lib/templates', templateName + '.hbs')).toString();
 
         return handlebars.compile(template)({
-            userId : `<@${userID}>`
+            userId : '<@' + userID + '>'
         });
     }
 

--- a/specs/lib/SlackBotSpec.js
+++ b/specs/lib/SlackBotSpec.js
@@ -19,17 +19,21 @@ describe('SlackBot', function () {
     var user = 'omar';
     var userID = '1';
     var displayName = 'Omar';
+    var devChannelId = '123';
     var configUrl = 'https://api.github.com/repos/owner/repo/contents/.slackbot.yml';
     var mockYAML;
 
     function setupFakeIDs() {
         SlackBot._userIDs = {};
         SlackBot._userData = {};
-        SlackBot._channelIDs = {};
+        SlackBot._channelIDs = {
+            'dev': devChannelId
+        };
 
         SlackBot._userIDs[user] = userID;
         SlackBot._userData[userID] = {
-            display_name: displayName
+            display_name: displayName,
+            id: userID
         };
         SlackBot._channelIDs['general'] = 1;
     }
@@ -38,7 +42,7 @@ describe('SlackBot', function () {
         var template = fs.readFileSync(path.join(__dirname, '../../lib/templates', templateName + '.hbs')).toString();
 
         return handlebars.compile(template)({
-            name : displayName
+            userId : `<@${userID}>`
         });
     }
 
@@ -99,7 +103,7 @@ describe('SlackBot', function () {
             });
     });
 
-    it('posts early release reminder.', function () {
+    it('posts early release reminder to #dev channel.', function () {
         spyOn(SlackBot, '_getConfig').and.callFake(function() {
             var releaseSchedule = {};
             releaseSchedule[user] = [earlyDate];
@@ -114,14 +118,14 @@ describe('SlackBot', function () {
 
         return SlackBot._sendReleaseReminders()
             .then(function() {
-                expect(SlackBot.postMessage).toHaveBeenCalledWith(userID, getMessage('releaseReminderEarly'));
+                expect(SlackBot.postMessage).toHaveBeenCalledWith(devChannelId, getMessage('releaseReminderEarly'));
             })
             .catch(function(error) {
                 throw Error(error);
             });
     });
 
-    it('posts release reminder.', function () {
+    it('posts release reminder to #dev channel.', function () {
         spyOn(SlackBot, '_getConfig').and.callFake(function() {
             var releaseSchedule = {};
             releaseSchedule[user] = [mediumDate];
@@ -136,14 +140,14 @@ describe('SlackBot', function () {
 
         return SlackBot._sendReleaseReminders()
         .then(function() {
-            expect(SlackBot.postMessage).toHaveBeenCalledWith(userID, getMessage('releaseReminder'));
+            expect(SlackBot.postMessage).toHaveBeenCalledWith(devChannelId, getMessage('releaseReminder'));
         })
         .catch(function(error) {
             throw Error(error);
         });
     });
 
-    it('posts late release reminder.', function () {
+    it('posts late release reminder to #dev channel.', function () {
         spyOn(SlackBot, '_getConfig').and.callFake(function() {
             var releaseSchedule = {};
             releaseSchedule[user] = [today];
@@ -158,7 +162,7 @@ describe('SlackBot', function () {
 
         return SlackBot._sendReleaseReminders()
         .then(function() {
-            expect(SlackBot.postMessage).toHaveBeenCalledWith(userID, getMessage('releaseReminderLate'));
+            expect(SlackBot.postMessage).toHaveBeenCalledWith(devChannelId, getMessage('releaseReminderLate'));
         })
         .catch(function(error) {
             throw Error(error);


### PR DESCRIPTION
This PR makes the slack bot post release reminders to the general `#dev` channel instead of directly to individuals that way everyone is aware when the release is happening and who's leading it. 

This required using the `userId` instead of the name so the user gets notified (this is what `link_names: true` does, see https://api.slack.com/methods/chat.postMessage#arg_link_names)

I also needed to use three curly brackets in the handlebars template to allow the special characters `<` in the message since the syntax is `<@userId>`. 