### PR TITLE
Add API for GitHub Contributors during ask about contributors check

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The table below describes all the possible configuration variables, as well as t
 | `repositories:{full_name}:gitHubToken` | `string` | Token used to verify __outgoing__ requests to GitHub repository | ✓ | 
 | `repositories:{full_name}:thirdPartyFolders` | `string` | Comma-separated list of folders in which to look for changed files in pull request to remind user to update License. | X | `[]`
 | `repositories:{full_name}:contributorsPath` | `string` |  Relative path from the root of the repository to the `CONTRIBUTORS.md` file. | X | _Disabled if not set._
+| `repositories:{full_name}:contributorsFromGitHub` | `string` |  Use the GitHub Contributors API to check for previous contributors to the repository. | X | _Disabled if not set._
 | `repositories:{full_name}:maxDaysSinceUpdate` | `number` | "Bump" pull requests older than this number of days ago. | X | `30`
 | `repositories:{full_name}:unitTestPath` | `string` |  Relative path to the directory containing unit tests. _Example:`Specs/`_ | X | _Disabled if not set._
 | `googleApiConfig` | `string` | Google API config for reading the list of CLA signers from Google Sheets. See [CLA checking](#cla-checking) for full instructions. | X | _Disabled if not set._

--- a/lib/RepositorySettings.js
+++ b/lib/RepositorySettings.js
@@ -48,6 +48,11 @@ function RepositorySettings(options) {
     this.contributorsPath = options.contributorsPath;
 
     /**
+     * Use the GitHub Contributors API
+     */
+    this.contributorsFromGitHub = defaultValue(options.contributorsFromGitHub, false);
+
+    /**
      * Gets the amount of days before a pull request is considered stale.
      */
     this.maxDaysSinceUpdate = defaultValue(options.maxDaysSinceUpdate, defaultMaxDaysSinceUpdate);

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -136,7 +136,7 @@ function findContributorFromGitHub(userName, repositoryContributorsUrl, reposito
     })
     .then(function (response) {
         var result = response.find(function(contributor) {
-            return respose.login === userName;
+            return contributor.login === userName;
         });
 
         return defined(result) ? result : findContributorFromGitHub(userName, repositoryContributorsUrl, repositorySettingsHeaders, page + 1);

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -142,7 +142,7 @@ commentOnOpenedPullRequest._askAboutContributors = function (userName, repositor
             var result = fullContributorsList.find(function(contributor) {
                 return contributor.login === userName;
             });
-            return defined(result);
+            return !defined(result);
         });
     }
 

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -6,6 +6,7 @@ var requestPromise = require('request-promise');
 var Settings = require('./Settings');
 
 var Check = Cesium.Check;
+var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 
 module.exports = commentOnOpenedPullRequest;
@@ -117,31 +118,39 @@ commentOnOpenedPullRequest._askAboutChanges = function (files, baseBranch) {
     return true;
 };
 
+function findContributorFromGitHub(userName, repositoryContributorsUrl, repositorySettingsHeaders, page) {
+    page = defaultValue(page, 1);
+
+    if (page > 5) {
+        return undefined;
+    }
+
+    return requestPromise.get({
+        url: repositoryContributorsUrl,
+        qs: {
+            per_page: 100,
+            page: page
+        },
+        headers: repositorySettingsHeaders,
+        json: true
+    })
+    .then(function (response) {
+        var result = response.find(function(contributor) {
+            return respose.login === userName;
+        });
+
+        return defined(result) ? result : findContributorFromGitHub(userName, repositoryContributorsUrl, repositorySettingsHeaders, page + 1);
+    });
+}
+
 commentOnOpenedPullRequest._askAboutContributors = function (userName, repositorySettings, headApiUrl, headBranch, repositoryContributorsUrl) {
     if (!defined(repositorySettings.contributorsPath) && !repositorySettings.contributorsFromGitHub) {
         return Promise.resolve(false);
     }
 
-    if (repositorySettings.contributorsFromGitHub) {
-        var contributorsPromises = [];
-        for (var i = 1; i < 6; i++) { // GitHub maintains only 500 named contributors
-            contributorsPromises[i - 1] = requestPromise.get({
-                url: repositoryContributorsUrl,
-                qs: {
-                    per_page: 100,
-                    page: i
-                },
-                headers: repositorySettings.headers,
-                json: true
-            });
-        }
-
-        return Promise.all(contributorsPromises)
-        .then(function (responses) {
-            var fullContributorsList = [].concat.apply([], responses);
-            var result = fullContributorsList.find(function(contributor) {
-                return contributor.login === userName;
-            });
+    if (repositorySettings.contributorsFromGitHub) { // GitHub maintains only 500 named contributors
+        return findContributorFromGitHub(userName, repositoryContributorsUrl, repositorySettings.headers)
+        .then(function (result) {
             return !defined(result);
         });
     }

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -32,11 +32,12 @@ function commentOnOpenedPullRequest(body, repositorySettings) {
 
     var repository = body.repository;
     var repositoryUrl = repository.html_url;
+    var repositoryContributorsUrl = repository.contributors_url;
 
-    return commentOnOpenedPullRequest._implementation(filesUrl, commentsUrl, repositorySettings, userName, repositoryUrl, baseBranch, headBranch, headHtmlUrl, headApiUrl);
+    return commentOnOpenedPullRequest._implementation(filesUrl, commentsUrl, repositorySettings, userName, repositoryUrl, baseBranch, headBranch, headHtmlUrl, headApiUrl, repositoryContributorsUrl);
 }
 
-commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, userName, repositoryUrl, baseBranch, headBranch, headHtmlUrl, headApiUrl) {
+commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, userName, repositoryUrl, baseBranch, headBranch, headHtmlUrl, headApiUrl, repositoryContributorsUrl) {
     // The google sheets API will fail to initialize if any of the required settings are missing.
     var claEnabled = defined(Settings.googleSheetsApi);
     var askForCla = false;
@@ -53,7 +54,7 @@ commentOnOpenedPullRequest._implementation = function (pullRequestFilesUrl, pull
             errorCla = error.toString();
         })
         .then(function () {
-            return commentOnOpenedPullRequest._askAboutContributors(userName, repositorySettings, headApiUrl, headBranch);
+            return commentOnOpenedPullRequest._askAboutContributors(userName, repositorySettings, headApiUrl, headBranch, repositoryContributorsUrl);
         })
         .then(function (result) {
             askAboutContributors = result;
@@ -116,9 +117,33 @@ commentOnOpenedPullRequest._askAboutChanges = function (files, baseBranch) {
     return true;
 };
 
-commentOnOpenedPullRequest._askAboutContributors = function (userName, repositorySettings, headApiUrl, headBranch) {
-    if (!defined(repositorySettings.contributorsPath)) {
+commentOnOpenedPullRequest._askAboutContributors = function (userName, repositorySettings, headApiUrl, headBranch, repositoryContributorsUrl) {
+    if (!defined(repositorySettings.contributorsPath) && !repositorySettings.contributorsFromGitHub) {
         return Promise.resolve(false);
+    }
+
+    if (repositorySettings.contributorsFromGitHub) {
+        var contributorsPromises = [];
+        for (var i = 1; i < 6; i++) { // GitHub maintains only 500 named contributors
+            contributorsPromises[i - 1] = requestPromise.get({
+                url: repositoryContributorsUrl,
+                qs: {
+                    per_page: 100,
+                    page: i
+                },
+                headers: repositorySettings.headers,
+                json: true
+            });
+        }
+
+        return Promise.all(contributorsPromises)
+        .then(function (responses) {
+            var fullContributorsList = [].concat.apply([], responses);
+            var result = fullContributorsList.find(function(contributor) {
+                return contributor.login === userName;
+            });
+            return defined(result);
+        });
     }
 
     var url = headApiUrl + '/contents/' + repositorySettings.contributorsPath + '?ref=' + headBranch;

--- a/lib/commentOnOpenedPullRequest.js
+++ b/lib/commentOnOpenedPullRequest.js
@@ -1,12 +1,12 @@
 'use strict';
 var Cesium = require('cesium');
+var parseLink = require('parse-link-header');
 var Promise = require('bluebird');
 var requestPromise = require('request-promise');
 
 var Settings = require('./Settings');
 
 var Check = Cesium.Check;
-var defaultValue = Cesium.defaultValue;
 var defined = Cesium.defined;
 
 module.exports = commentOnOpenedPullRequest;
@@ -118,28 +118,27 @@ commentOnOpenedPullRequest._askAboutChanges = function (files, baseBranch) {
     return true;
 };
 
-function findContributorFromGitHub(userName, repositoryContributorsUrl, repositorySettingsHeaders, page) {
-    page = defaultValue(page, 1);
-
-    if (page > 5) {
-        return undefined;
-    }
-
+function findContributorFromGitHub(userName, repositoryContributorsUrl, repositorySettingsHeaders) {
     return requestPromise.get({
         url: repositoryContributorsUrl,
-        qs: {
-            per_page: 100,
-            page: page
-        },
         headers: repositorySettingsHeaders,
-        json: true
+        json: true,
+        resolveWithFullResponse: true
     })
     .then(function (response) {
-        var result = response.find(function(contributor) {
+        var contributors = response.body;
+        var result = contributors.find(function(contributor) {
             return contributor.login === userName;
         });
 
-        return defined(result) ? result : findContributorFromGitHub(userName, repositoryContributorsUrl, repositorySettingsHeaders, page + 1);
+        if (defined(result)) {
+            return result;
+        }
+
+        var linkData = parseLink(response.headers.link);
+        if (defined(linkData) && defined(linkData.next)) {
+            return findContributorFromGitHub(userName, linkData.next.url, repositorySettingsHeaders);
+        }
     });
 }
 

--- a/specs/lib/commentOnOpenedPullRequestSpec.js
+++ b/specs/lib/commentOnOpenedPullRequestSpec.js
@@ -15,6 +15,7 @@ describe('commentOnOpenedPullRequest', function () {
     var userName = 'boomerJones';
     var repositoryName = 'AnalyticalGraphics/cesium';
     var repositoryUrl = 'https://github.com/AnalyticalGraphicsInc/cesium';
+    var repositoryContributorsUrl = 'https://api.github.com/repos/AnalyticalGraphicsInc/cesium/contributors';
     var thirdPartyFolders = ['ThirdParty/', 'Source/ThirdParty/'];
     var baseBranch = 'master';
     var headBranch = 'feature';
@@ -41,6 +42,7 @@ describe('commentOnOpenedPullRequest', function () {
         },
         repository: {
             html_url: repositoryUrl,
+            contributors_url: repositoryContributorsUrl,
             full_name: repositoryName
         }
     };
@@ -114,7 +116,7 @@ describe('commentOnOpenedPullRequest', function () {
 
         commentOnOpenedPullRequest(pullRequestJson, repositorySettings);
 
-        expect(commentOnOpenedPullRequest._implementation).toHaveBeenCalledWith(filesUrl, commentsUrl, repositorySettings, userName, repositoryUrl, baseBranch, headBranch, headHtmlUrl, headApiUrl);
+        expect(commentOnOpenedPullRequest._implementation).toHaveBeenCalledWith(filesUrl, commentsUrl, repositorySettings, userName, repositoryUrl, baseBranch, headBranch, headHtmlUrl, headApiUrl, repositoryContributorsUrl);
     });
 
     it('commentOnOpenedPullRequest._askAboutChanges works', function () {
@@ -614,7 +616,7 @@ describe('commentOnOpenedPullRequest', function () {
             return Promise.reject('Unknown url: ' + options.url);
         });
 
-        commentOnOpenedPullRequest._implementation(pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, newContributor, repositoryUrl, baseBranch, headBranch, headHtmlUrl, headApiUrl)
+        commentOnOpenedPullRequest._implementation(pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, newContributor, repositoryUrl, baseBranch, headBranch, headHtmlUrl, headApiUrl, repositoryContributorsUrl)
             .then(function () {
                 expect(requestPromise.post).toHaveBeenCalledWith({
                     url: pullRequestCommentsUrl,
@@ -670,7 +672,7 @@ describe('commentOnOpenedPullRequest', function () {
             return Promise.reject('Unknown url: ' + options.url);
         });
 
-        commentOnOpenedPullRequest._implementation(pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, userName, repositoryUrl, baseBranch, headBranch, headHtmlUrl, headApiUrl)
+        commentOnOpenedPullRequest._implementation(pullRequestFilesUrl, pullRequestCommentsUrl, repositorySettings, userName, repositoryUrl, baseBranch, headBranch, headHtmlUrl, headApiUrl, repositoryContributorsUrl)
             .then(function () {
                 expect(requestPromise.post).toHaveBeenCalledWith({
                     url: pullRequestCommentsUrl,


### PR DESCRIPTION
Adds an option to check the GitHub contributors list for first-time contributors. This is useful if CONTRIBUTORS.md is not maintained in the repo, and GitHub Contributors API can be used.

Here is a simple gulp task that can be used from CLI

```
var Promise = require('bluebird');
var requestPromise = require('request-promise');

gulp.task('contributors', function () {
    var repositoryContributorsUrl = 'https://api.github.com/repos/AnalyticalGraphicsInc/cesium/contributors';
    var contributorsPromises = [];
    for (var i = 1; i < 6; i++) { // GitHub maintains only 500 named contributors
        contributorsPromises[i - 1] = requestPromise.get({
            url: repositoryContributorsUrl,
            qs: {
                per_page: 100,
                page: i
            },
            headers: {
                'User-Agent': 'cesium-concierge'
            },
            json: true
        });
    }

    return Promise.all(contributorsPromises)
        .then(function (responses) {
            var fullContributorsList = [].concat.apply([], responses);
            var result = fullContributorsList.find(function(contributor) {
                return contributor.login === 'shehzan10';
            });
            console.log(fullContributorsList.length);
            console.log(result);
        });
});
```

Fixes #152 